### PR TITLE
Removed static reference to .dll SlimDx and reimplmented it as a nuge…

### DIFF
--- a/src/Demos/SlimDxDemo/SlimDxDemo.csproj
+++ b/src/Demos/SlimDxDemo/SlimDxDemo.csproj
@@ -69,7 +69,8 @@
       <HintPath>..\..\packages\UnmanagedExports.1.2.4.23262\lib\net\RGiesecke.DllExport.Metadata.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SlimDX, Version=2.0.11.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
+    <Reference Include="SlimDX, Version=2.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
+      <HintPath>..\..\packages\SlimDX.4.0.13.44\lib\NET20\SlimDX.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Demos/SlimDxDemo/packages.config
+++ b/src/Demos/SlimDxDemo/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="SlimDX" version="4.0.13.44" targetFramework="net35" />
   <package id="UnmanagedExports" version="1.2.4.23262" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
…t package

The SlimDx plugin wouldn't compile as it relied an static .dll reference to the framework SlimDx. The static reference was removed, and SlimDx was re-implemented as a nuget package
